### PR TITLE
cameraservice: Avoid calling getSystemCameraKind if the camera was no…

### DIFF
--- a/services/camera/libcameraservice/CameraService.h
+++ b/services/camera/libcameraservice/CameraService.h
@@ -995,8 +995,7 @@ private:
     // handle torch mode status change and invoke callbacks. mTorchStatusMutex
     // should be locked.
     void onTorchStatusChangedLocked(const String8& cameraId,
-            hardware::camera::common::V1_0::TorchModeStatus newStatus,
-            SystemCameraKind systemCameraKind);
+            hardware::camera::common::V1_0::TorchModeStatus newStatus);
 
     // get a camera's torch status. mTorchStatusMutex should be locked.
     status_t getTorchStatusLocked(const String8 &cameraId,
@@ -1085,8 +1084,7 @@ private:
     static void pingCameraServiceProxy();
 
     void broadcastTorchModeStatus(const String8& cameraId,
-            hardware::camera::common::V1_0::TorchModeStatus status,
-            SystemCameraKind systemCameraKind);
+            hardware::camera::common::V1_0::TorchModeStatus status);
 
     void disconnectClient(const String8& id, sp<BasicClient> clientToDisconnect);
 


### PR DESCRIPTION
…t mapped yet

* By calling `getSystemCameraKind()` directly in
  `broadcastTorchModeStatus()` we ensure that previous calls to
  `getTorchStatusLocked` and `setTorchStatusLocked` had succeeded,
  meaning that the camera device is already present in mCameraStates.

  When the camera device is already mapped in mCameraStates
  calls to `getSystemCameraKind()` will avoid interrogating the
  CameraProviderManager, which was causing a deadlock
  upon attempting to lock mInterfaceLock.

Change-Id: I2aed9d53f13859d26efe6a8ab300afab6944f5f7